### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ var config = new Configuration(configPath: "path/to/my.config")
 var config = Configuration.Load<MyApplication>(configPath: "path/to/my.config");
 ```
 
-SimpleConfig uses [Bender](https://github.com/mikeobrien/Bender) for deserialization. Bender configuration can be passed in to customize deserialization. For example, you can specify custom readers to handle the deserialization of certian data types:
+SimpleConfig uses [Bender](https://github.com/mikeobrien/Bender) for deserialization. Bender configuration can be passed in to customize deserialization. For example, you can specify custom readers to handle the deserialization of certain data types:
 
 ```csharp
 var config = new Configuration(x => x


### PR DESCRIPTION
@mikeobrien, I've corrected a typographical error in the documentation of the [SimpleConfig](https://github.com/mikeobrien/SimpleConfig) project. Specifically, I've changed certian to certain. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
